### PR TITLE
Net 7 migration

### DIFF
--- a/SDDev.Net.GenericRepository.Contracts/SDDev.Net.GenericRepository.Contracts.csproj
+++ b/SDDev.Net.GenericRepository.Contracts/SDDev.Net.GenericRepository.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SDDev.Net.GenericRepository.Example/SDDev.Net.GenericRepository.Example.csproj
+++ b/SDDev.Net.GenericRepository.Example/SDDev.Net.GenericRepository.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/SDDev.Net.GenericRepository.Tests/SDDev.Net.GenericRepository.Tests.csproj
+++ b/SDDev.Net.GenericRepository.Tests/SDDev.Net.GenericRepository.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SDDev.Net.GenericRepository.Tests/SDDev.Net.GenericRepository.Tests.csproj
+++ b/SDDev.Net.GenericRepository.Tests/SDDev.Net.GenericRepository.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />

--- a/SDDev.Net.GenericRepository/SDDev.Net.GenericRepository.csproj
+++ b/SDDev.Net.GenericRepository/SDDev.Net.GenericRepository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+	  <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SDDev.Net.GenericRepository/SDDev.Net.GenericRepository.csproj
+++ b/SDDev.Net.GenericRepository/SDDev.Net.GenericRepository.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="AutoMapper" Version="10.1.1" />
-	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+	<PackageReference Include="AutoMapper" Version="12.0.0" />
+	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
 	<PackageReference Include="Azure.Search.Documents" Version="11.3.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="LINQKit.Core" Version="1.2.2" />


### PR DESCRIPTION
- Libraries now required Net7
- AutoMapper updated to version 12.0.0
- AutoMapper.Extensions.Microsoft.DependencyInjection updated to version 12.0.0