### PR TITLE
add config to populate index metrics

### DIFF
--- a/SDDev.Net.GenericRepository/CosmosDB/GenericRepository.cs
+++ b/SDDev.Net.GenericRepository/CosmosDB/GenericRepository.cs
@@ -31,7 +31,6 @@ namespace SDDev.Net.GenericRepository.CosmosDB
         {
             try
             {
-
                 if(string.IsNullOrEmpty(partitionKey))
                     return await FindOne(x => x.Id == id).ConfigureAwait(false);
                 
@@ -62,7 +61,12 @@ namespace SDDev.Net.GenericRepository.CosmosDB
         /// <returns></returns>
         public override async Task<ISearchResult<TModel>> Get(Expression<Func<TModel, bool>> predicate, ISearchModel model)
         {
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = model.PageSize };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = model.PageSize,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
+
             if (!string.IsNullOrEmpty(model.PartitionKey))
                 queryOptions.PartitionKey = new PartitionKey(model.PartitionKey);
             else
@@ -146,7 +150,11 @@ namespace SDDev.Net.GenericRepository.CosmosDB
         /// <returns></returns>
         public async override Task<ISearchResult<TModel>> Get(string query, ISearchModel model)
         {
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = model.PageSize };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = model.PageSize,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
 
             if (!string.IsNullOrEmpty(model.PartitionKey))
                 queryOptions.PartitionKey = new PartitionKey(model.PartitionKey);
@@ -403,7 +411,11 @@ namespace SDDev.Net.GenericRepository.CosmosDB
 
         public override async Task<TModel> FindOne(Expression<Func<TModel, bool>> predicate, string partitionKey = null, bool singleResult = false)
         {
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = 2 };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = 2,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
 
             if (!singleResult)
             {

--- a/SDDev.Net.GenericRepository/CosmosDB/GenericRepository.cs
+++ b/SDDev.Net.GenericRepository/CosmosDB/GenericRepository.cs
@@ -114,6 +114,12 @@ namespace SDDev.Net.GenericRepository.CosmosDB
 
             var result = query.ToFeedIterator();
             var res = await result.ReadNextAsync();
+
+            if (Configuration.PopulateIndexMetrics)
+            {
+                Log.LogWarning("Index Metrics {metrics}", res.IndexMetrics);
+            }
+
             if (res.RequestCharge < 100)
                 Log.LogInformation($"Request used {res.RequestCharge} RUs.| Query: {result}");
             else if (res.RequestCharge < 200)
@@ -204,6 +210,12 @@ namespace SDDev.Net.GenericRepository.CosmosDB
             var result = q.ToFeedIterator();
 
             var res = await result.ReadNextAsync();
+
+            if (Configuration.PopulateIndexMetrics)
+            {
+                Log.LogWarning("Index Metrics {metrics}", res.IndexMetrics);
+            }
+
             if (res.RequestCharge < 100)
                 Log.LogInformation($"Request used {res.RequestCharge} RUs.| Query: {result}");
             else if (res.RequestCharge < 200)
@@ -431,7 +443,14 @@ namespace SDDev.Net.GenericRepository.CosmosDB
                     var iterator = query.ToFeedIterator();
                     while (iterator.HasMoreResults)
                     {
-                        items.AddRange(await iterator.ReadNextAsync());
+                        var res = await iterator.ReadNextAsync();
+
+                        if (Configuration.PopulateIndexMetrics)
+                        {
+                            Log.LogWarning("Index Metrics {metrics}", res.IndexMetrics);
+                        }
+
+                        items.AddRange(res);
                     }
 
                     return items.FirstOrDefault();

--- a/SDDev.Net.GenericRepository/CosmosDB/HierarchicalPartitionedRepository.cs
+++ b/SDDev.Net.GenericRepository/CosmosDB/HierarchicalPartitionedRepository.cs
@@ -134,7 +134,11 @@ namespace SDDev.Net.GenericRepository.CosmosDB
             if (string.IsNullOrEmpty(partitionKey))
                 return await FindOne(x => x.Id == id).ConfigureAwait(false);
 
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = 2 };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = 2,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
             var partitionKeyQuery = $"{PartitionKeys.First()}=\"{partitionKey}\"";
             var query = Client
                         .GetItemLinqQueryable<TModel>(requestOptions: queryOptions, allowSynchronousQueryExecution: true)
@@ -185,7 +189,11 @@ namespace SDDev.Net.GenericRepository.CosmosDB
         }
 
         public override Task<ISearchResult<TModel>> Get(string query, ISearchModel model){
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = model.PageSize };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = model.PageSize,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
 
             if (!string.IsNullOrEmpty(model.ContinuationToken))
             {
@@ -204,7 +212,11 @@ namespace SDDev.Net.GenericRepository.CosmosDB
 
         public override Task<ISearchResult<TModel>> Get(Expression<Func<TModel, bool>> predicate, ISearchModel model)
         {
-            var queryOptions = new QueryRequestOptions() { MaxItemCount = model.PageSize };
+            var queryOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = model.PageSize,
+                PopulateIndexMetrics = Configuration.PopulateIndexMetrics,
+            };
             
             if (!string.IsNullOrEmpty(model.ContinuationToken))
             {

--- a/SDDev.Net.GenericRepository/CosmosDB/Utilities/DocumentDbConfiguration.cs
+++ b/SDDev.Net.GenericRepository/CosmosDB/Utilities/DocumentDbConfiguration.cs
@@ -13,5 +13,6 @@
         public string ConnectionString { get; set; }
 
         public bool EnableBulkQuerying { get; set; } = true;
+        public bool PopulateIndexMetrics { get; set; } = false;
     }
 }


### PR DESCRIPTION
add a configuration flag to toggle whether queries will print the recommendations for what indexes were used and what changes could help improve query performance.